### PR TITLE
feat: upload documents to OpenAI vectorstore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django
 pgvector
 docling
+openai


### PR DESCRIPTION
## Summary
- add `upload_to_vectorstore` helper on `Document`
- require `openai` dependency
- add admin action to send selected docs to the OpenAI vector store

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688db9f23c64832887a94be3713362f4