### PR TITLE
Add vector store search API endpoint

### DIFF
--- a/mevzuat/documents/api.py
+++ b/mevzuat/documents/api.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+from ninja import Router, Schema
+from openai import OpenAI
+
+
+router = Router()
+
+
+class VectorSearchPayload(Schema):
+    query: str
+    limit: int = 10
+    score_threshold: Optional[float] = None
+    rewrite_query: bool = True
+
+
+@router.post("/vector-stores/{vs_id}/search")
+def search_vector_store(request, vs_id: str, payload: VectorSearchPayload):
+    """Query a vector store and return relevant results."""
+    client = OpenAI()
+    ranking_options = {}
+    if payload.score_threshold is not None:
+        ranking_options["score_threshold"] = payload.score_threshold
+    response = client.vector_stores.search(
+        vector_store_id=vs_id,
+        query=payload.query,
+        max_num_results=payload.limit,
+        ranking_options=ranking_options or None,
+        rewrite_query=payload.rewrite_query,
+    )
+    return response

--- a/mevzuat/urls.py
+++ b/mevzuat/urls.py
@@ -16,7 +16,15 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from ninja import NinjaAPI
+from mevzuat.documents.api import router as documents_router
+
+
+api = NinjaAPI()
+api.add_router("/documents", documents_router)
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path("api/", api.urls),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django
 pgvector
 docling
 openai
+django-ninja


### PR DESCRIPTION
## Summary
- add Django Ninja endpoint for searching OpenAI vector stores
- expose new router under `/api/documents`
- include django-ninja in requirements
- default `rewrite_query` to true for vector store searches

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_688de57377288328b705a1b06a2a2d58