### PR TITLE
Expose configured vector stores via API and query them from frontend

### DIFF
--- a/mevzuat/documents/api.py
+++ b/mevzuat/documents/api.py
@@ -1,10 +1,18 @@
 from typing import Optional
 
+from django.conf import settings
 from ninja import Router, Schema
 from openai import OpenAI
 
 
 router = Router()
+
+
+class VectorStoreOut(Schema):
+    """Schema representing an available vector store."""
+
+    name: str
+    id: str
 
 
 class VectorSearchPayload(Schema):
@@ -29,3 +37,13 @@ def search_vector_store(request, vs_id: str, payload: VectorSearchPayload):
         rewrite_query=payload.rewrite_query,
     )
     return response
+
+
+@router.get("/vector-stores", response=list[VectorStoreOut])
+def list_vector_stores(request):
+    """Return the vector stores configured in settings."""
+
+    return [
+        {"name": name, "id": vs_id}
+        for name, vs_id in settings.VECTORSTORES.items()
+    ]


### PR DESCRIPTION
## Summary
- add a Ninja API endpoint that lists vector stores defined in settings
- search page fetches the list and queries every vector store

## Testing
- `python manage.py test`
- `npm --prefix frontend run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_688e49c1aca083288f662d60451299c2