### PR TITLE
feat: extend chart palette

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -16,6 +16,11 @@
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar: var(--sidebar);
+  --color-chart-10: var(--chart-10);
+  --color-chart-9: var(--chart-9);
+  --color-chart-8: var(--chart-8);
+  --color-chart-7: var(--chart-7);
+  --color-chart-6: var(--chart-6);
   --color-chart-5: var(--chart-5);
   --color-chart-4: var(--chart-4);
   --color-chart-3: var(--chart-3);
@@ -68,6 +73,11 @@
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
+  --chart-6: #edc948;
+  --chart-7: #b07aa1;
+  --chart-8: #ff9da7;
+  --chart-9: #9c755f;
+  --chart-10: #bab0ac;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -102,6 +112,11 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
+  --chart-6: #edc948;
+  --chart-7: #b07aa1;
+  --chart-8: #ff9da7;
+  --chart-9: #9c755f;
+  --chart-10: #bab0ac;
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);


### PR DESCRIPTION
## Summary
- add missing chart colors 6-10 for light/dark themes
- expose new chart colors through theme variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6890932196f88328a8ac25f75a5c4bca