### PR TITLE
Expand document list date filters

### DIFF
--- a/mevzuat/documents/api.py
+++ b/mevzuat/documents/api.py
@@ -90,13 +90,31 @@ def document_counts(request) -> list[dict[str, Any]]:
     ]
 
 
-@router.get("/list", response=list[MevzuatOut])
-def list_documents(request, mevzuat_tur: Optional[int] = None, year: Optional[int] = None):
-    """Return documents filtered by type and/or publication year."""
+@router.get("/", response=list[MevzuatOut])
+def list_documents(
+    request,
+    mevzuat_tur: Optional[int] = None,
+    year: Optional[int] = None,
+    month: Optional[int] = None,
+    date: Optional[date] = None,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+):
+    """Return documents filtered by type and/or publication date."""
 
     qs = Mevzuat.objects.all()
     if mevzuat_tur is not None:
         qs = qs.filter(mevzuat_tur=mevzuat_tur)
     if year is not None:
         qs = qs.filter(resmi_gazete_tarihi__year=year)
+    if month is not None:
+        qs = qs.filter(resmi_gazete_tarihi__month=month)
+    if date is not None:
+        qs = qs.filter(resmi_gazete_tarihi=date)
+    if start_date is not None and end_date is not None:
+        qs = qs.filter(resmi_gazete_tarihi__range=(start_date, end_date))
+    elif start_date is not None:
+        qs = qs.filter(resmi_gazete_tarihi__gte=start_date)
+    elif end_date is not None:
+        qs = qs.filter(resmi_gazete_tarihi__lte=end_date)
     return qs

--- a/mevzuat/documents/tests.py
+++ b/mevzuat/documents/tests.py
@@ -64,3 +64,25 @@ class DocumentListAPITest(TestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["mevzuat_tur"], 1)
         self.assertTrue(data[0]["resmi_gazete_tarihi"].startswith("2021"))
+
+    def test_filter_by_month(self):
+        response = self.client.get("/api/documents/", {"month": 1})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertTrue(all(item["resmi_gazete_tarihi"][5:7] == "01" for item in data))
+
+    def test_filter_by_date(self):
+        response = self.client.get("/api/documents/", {"date": "2021-05-05"})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["resmi_gazete_tarihi"], "2021-05-05")
+
+    def test_filter_by_date_range(self):
+        params = {"start_date": "2020-01-01", "end_date": "2021-04-30"}
+        response = self.client.get("/api/documents/", params)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertTrue(all("2020-01-01" <= item["resmi_gazete_tarihi"] <= "2021-04-30" for item in data))


### PR DESCRIPTION
## Summary
- support month, exact date, and start/end date range filters in document list API
- add tests for new date filtering

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68918e04c42883288937ff66eb2c3fe8