### PR TITLE
refactor: update document API for new model

### DIFF
--- a/mevzuat/documents/api.py
+++ b/mevzuat/documents/api.py
@@ -2,12 +2,12 @@ from typing import Optional, Any
 from datetime import date
 
 from django.conf import settings
-from django.db.models import Count, Min
-from django.db.models.functions import ExtractYear
+from django.db.models import Count, Min, IntegerField, DateField
+from django.db.models.functions import ExtractYear, Cast, TruncDay, TruncMonth
 from ninja import Router, Schema
 from openai import OpenAI
 
-from .models import Document
+from .models import Document, DocumentType
 
 
 router = Router()
@@ -31,12 +31,14 @@ class DocumentOut(Schema):
     """Schema representing a document."""
 
     id: int
-    name: str
+    title: str
     mevzuat_tur: int
-    resmi_gazete_tarihi: Optional[date]
+    document_date: Optional[date]
 
     class Config:
         from_attributes = True
+
+
 
 
 @router.post("/vector-stores/{vs_id}/search")
@@ -81,30 +83,36 @@ def document_counts(
     """
 
     from datetime import timedelta, datetime
-    from django.db.models.functions import TruncDay, TruncMonth
 
     if end_date is None:
         end_date = date.today()
     if start_date is None:
         earliest = (
-            Document.objects.exclude(resmi_gazete_tarihi__isnull=True)
-            .aggregate(Min("resmi_gazete_tarihi"))
-            .get("resmi_gazete_tarihi__min")
+            Document.objects.exclude(metadata__resmi_gazete_tarihi__isnull=True)
+            .annotate(rg_date=Cast("metadata__resmi_gazete_tarihi", DateField()))
+            .aggregate(Min("rg_date"))
+            .get("rg_date__min")
         )
         start_date = earliest or (end_date - timedelta(days=30))
 
+    type_labels = dict(DocumentType.objects.values_list("id", "name"))
+
     qs = (
-        Document.objects.exclude(resmi_gazete_tarihi__isnull=True)
-        .filter(resmi_gazete_tarihi__range=(start_date, end_date))
-        .filter(mevzuat_tur__in=[1, 4, 19, 20, 21, 22])
+        Document.objects.exclude(metadata__resmi_gazete_tarihi__isnull=True)
+        .annotate(
+            mevzuat_tur=Cast("metadata__mevzuat_tur", IntegerField()),
+            rg_date=Cast("metadata__resmi_gazete_tarihi", DateField()),
+        )
+        .filter(rg_date__range=(start_date, end_date))
+        .filter(mevzuat_tur__in=type_labels.keys())
     )
 
     if interval == "month":
-        qs = qs.annotate(period=TruncMonth("resmi_gazete_tarihi"))
+        qs = qs.annotate(period=TruncMonth("rg_date"))
     elif interval == "year":
-        qs = qs.annotate(period=ExtractYear("resmi_gazete_tarihi"))
+        qs = qs.annotate(period=ExtractYear("rg_date"))
     else:
-        qs = qs.annotate(period=TruncDay("resmi_gazete_tarihi"))
+        qs = qs.annotate(period=TruncDay("rg_date"))
 
     qs = (
         qs.values("period", "mevzuat_tur")
@@ -112,7 +120,6 @@ def document_counts(
         .order_by("period", "mevzuat_tur")
     )
 
-    label_map = dict(Document._meta.get_field("mevzuat_tur").choices)
     result: dict[str, dict[str, int]] = {}
     for row in qs:
         period_val = row["period"]
@@ -120,7 +127,7 @@ def document_counts(
             key = period_val.isoformat()
         else:
             key = str(period_val)
-        label = label_map.get(row["mevzuat_tur"], str(row["mevzuat_tur"]))
+        label = type_labels.get(row["mevzuat_tur"], str(row["mevzuat_tur"]))
         result.setdefault(key, {})[label] = row["count"]
     return [{"date": k, **counts} for k, counts in sorted(result.items())]
 
@@ -137,19 +144,22 @@ def list_documents(
 ):
     """Return documents filtered by type and/or publication date."""
 
-    qs = Document.objects.all()
+    qs = Document.objects.annotate(
+        mevzuat_tur=Cast("metadata__mevzuat_tur", IntegerField()),
+        document_date=Cast("metadata__resmi_gazete_tarihi", DateField()),
+    )
     if mevzuat_tur is not None:
         qs = qs.filter(mevzuat_tur=mevzuat_tur)
     if year is not None:
-        qs = qs.filter(resmi_gazete_tarihi__year=year)
+        qs = qs.filter(document_date__year=year)
     if month is not None:
-        qs = qs.filter(resmi_gazete_tarihi__month=month)
+        qs = qs.filter(document_date__month=month)
     if date is not None:
-        qs = qs.filter(resmi_gazete_tarihi=date)
+        qs = qs.filter(document_date=date)
     if start_date is not None and end_date is not None:
-        qs = qs.filter(resmi_gazete_tarihi__range=(start_date, end_date))
+        qs = qs.filter(document_date__range=(start_date, end_date))
     elif start_date is not None:
-        qs = qs.filter(resmi_gazete_tarihi__gte=start_date)
+        qs = qs.filter(document_date__gte=start_date)
     elif end_date is not None:
-        qs = qs.filter(resmi_gazete_tarihi__lte=end_date)
+        qs = qs.filter(document_date__lte=end_date)
     return qs

--- a/mevzuat/documents/tests.py
+++ b/mevzuat/documents/tests.py
@@ -5,7 +5,7 @@ import tempfile
 from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings
 
-from .models import Mevzuat
+from .models import Document, DocumentType
 
 
 class DocumentListAPITest(TestCase):
@@ -14,29 +14,45 @@ class DocumentListAPITest(TestCase):
         self.override = override_settings(MEDIA_ROOT=self.tempdir)
         self.override.enable()
 
-        Mevzuat.objects.create(
-            name="Law 1",
-            mevzuat_tur=1,
-            mevzuat_no="1",
-            mevzuat_tertib=1,
+        type1 = DocumentType.objects.create(
+            id=1, name="Kanun", fetcher="MevzuatFetcher"
+        )
+        type2 = DocumentType.objects.create(
+            id=2, name="Tüzük", fetcher="MevzuatFetcher"
+        )
+
+        Document.objects.create(
+            title="Law 1",
+            type=type1,
             document=ContentFile(b"a", name="law1.pdf"),
-            resmi_gazete_tarihi=date(2020, 1, 1),
+            metadata={
+                "mevzuat_tur": 1,
+                "mevzuat_no": "1",
+                "mevzuat_tertib": 1,
+                "resmi_gazete_tarihi": "2020-01-01",
+            },
         )
-        Mevzuat.objects.create(
-            name="Law 2",
-            mevzuat_tur=2,
-            mevzuat_no="2",
-            mevzuat_tertib=1,
+        Document.objects.create(
+            title="Law 2",
+            type=type2,
             document=ContentFile(b"b", name="law2.pdf"),
-            resmi_gazete_tarihi=date(2021, 1, 1),
+            metadata={
+                "mevzuat_tur": 2,
+                "mevzuat_no": "2",
+                "mevzuat_tertib": 1,
+                "resmi_gazete_tarihi": "2021-01-01",
+            },
         )
-        Mevzuat.objects.create(
-            name="Law 3",
-            mevzuat_tur=1,
-            mevzuat_no="3",
-            mevzuat_tertib=1,
+        Document.objects.create(
+            title="Law 3",
+            type=type1,
             document=ContentFile(b"c", name="law3.pdf"),
-            resmi_gazete_tarihi=date(2021, 5, 5),
+            metadata={
+                "mevzuat_tur": 1,
+                "mevzuat_no": "3",
+                "mevzuat_tertib": 1,
+                "resmi_gazete_tarihi": "2021-05-05",
+            },
         )
 
     def tearDown(self):
@@ -55,7 +71,7 @@ class DocumentListAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 2)
-        self.assertTrue(all(item["resmi_gazete_tarihi"].startswith("2021") for item in data))
+        self.assertTrue(all(item["document_date"].startswith("2021") for item in data))
 
     def test_filter_by_both(self):
         response = self.client.get("/api/documents/", {"mevzuat_tur": 1, "year": 2021})
@@ -63,21 +79,21 @@ class DocumentListAPITest(TestCase):
         data = response.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["mevzuat_tur"], 1)
-        self.assertTrue(data[0]["resmi_gazete_tarihi"].startswith("2021"))
+        self.assertTrue(data[0]["document_date"].startswith("2021"))
 
     def test_filter_by_month(self):
         response = self.client.get("/api/documents/", {"month": 1})
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 2)
-        self.assertTrue(all(item["resmi_gazete_tarihi"][5:7] == "01" for item in data))
+        self.assertTrue(all(item["document_date"][5:7] == "01" for item in data))
 
     def test_filter_by_date(self):
         response = self.client.get("/api/documents/", {"date": "2021-05-05"})
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]["resmi_gazete_tarihi"], "2021-05-05")
+        self.assertEqual(data[0]["document_date"], "2021-05-05")
 
     def test_filter_by_date_range(self):
         params = {"start_date": "2020-01-01", "end_date": "2021-04-30"}
@@ -85,4 +101,4 @@ class DocumentListAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 2)
-        self.assertTrue(all("2020-01-01" <= item["resmi_gazete_tarihi"] <= "2021-04-30" for item in data))
+        self.assertTrue(all("2020-01-01" <= item["document_date"] <= "2021-04-30" for item in data))


### PR DESCRIPTION
## Summary
- adapt document API to new model using metadata for type and publication date
- expose `title` and `document_date` in API responses
- update API tests to create new `Document` objects with metadata
- derive document type labels from `DocumentType` instances instead of static constants

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_6893b5615fc883289bcec1b3b5a4af46