### PR TITLE
feat: add document types endpoint

### DIFF
--- a/mevzuat/documents/api.py
+++ b/mevzuat/documents/api.py
@@ -44,6 +44,16 @@ class DocumentOut(Schema):
         populate_by_name = True
 
 
+class DocumentTypeOut(Schema):
+    """Schema representing a document type."""
+
+    id: int
+    label: str = Field(..., alias="name")
+
+    class Config:
+        from_attributes = True
+
+
 @router.post("/vector-stores/{vs_uuid}/search")
 def search_vector_store(
     request,
@@ -104,6 +114,12 @@ def list_vector_stores(request):
 
     # Convert QuerySet of dicts to list so Ninja can serialise it cleanly
     return list(qs)
+
+
+@router.get("/types", response=List[DocumentTypeOut])
+def list_document_types(request):
+    """Return all available document types ordered by name."""
+    return DocumentType.objects.only("id", "name").order_by("name")
 
 
 @router.get("/counts")

--- a/mevzuat/documents/tests.py
+++ b/mevzuat/documents/tests.py
@@ -60,45 +60,63 @@ class DocumentListAPITest(TestCase):
         shutil.rmtree(self.tempdir)
 
     def test_filter_by_mevzuat_tur(self):
-        response = self.client.get("/api/documents/", {"mevzuat_tur": 1})
+        response = self.client.get("/api/documents/list", {"type": 1})
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 2)
-        self.assertTrue(all(item["mevzuat_tur"] == 1 for item in data))
+        self.assertTrue(all(item["type"] == 1 for item in data))
 
     def test_filter_by_year(self):
-        response = self.client.get("/api/documents/", {"year": 2021})
+        response = self.client.get("/api/documents/list", {"year": 2021})
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 2)
-        self.assertTrue(all(item["document_date"].startswith("2021") for item in data))
+        self.assertTrue(all(item["date"].startswith("2021") for item in data))
 
     def test_filter_by_both(self):
-        response = self.client.get("/api/documents/", {"mevzuat_tur": 1, "year": 2021})
+        response = self.client.get("/api/documents/list", {"type": 1, "year": 2021})
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]["mevzuat_tur"], 1)
-        self.assertTrue(data[0]["document_date"].startswith("2021"))
+        self.assertEqual(data[0]["type"], 1)
+        self.assertTrue(data[0]["date"].startswith("2021"))
 
     def test_filter_by_month(self):
-        response = self.client.get("/api/documents/", {"month": 1})
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(len(data), 2)
-        self.assertTrue(all(item["document_date"][5:7] == "01" for item in data))
-
-    def test_filter_by_date(self):
-        response = self.client.get("/api/documents/", {"date": "2021-05-05"})
+        response = self.client.get("/api/documents/list", {"year": 2021, "month": 1})
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]["document_date"], "2021-05-05")
+        self.assertTrue(all(item["date"].startswith("2021-01") for item in data))
+
+    def test_filter_by_date(self):
+        response = self.client.get("/api/documents/list", {"date": "2021-05-05"})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["date"], "2021-05-05")
 
     def test_filter_by_date_range(self):
         params = {"start_date": "2020-01-01", "end_date": "2021-04-30"}
-        response = self.client.get("/api/documents/", params)
+        response = self.client.get("/api/documents/list", params)
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 2)
-        self.assertTrue(all("2020-01-01" <= item["document_date"] <= "2021-04-30" for item in data))
+        self.assertTrue(all("2020-01-01" <= item["date"] <= "2021-04-30" for item in data))
+
+
+class DocumentTypeAPITest(TestCase):
+    def setUp(self):
+        DocumentType.objects.create(id=1, name="Kanun", fetcher="MevzuatFetcher")
+        DocumentType.objects.create(id=2, name="Tüzük", fetcher="MevzuatFetcher")
+
+    def test_list_document_types(self):
+        response = self.client.get("/api/documents/types")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(
+            data,
+            [
+                {"id": 1, "label": "Kanun"},
+                {"id": 2, "label": "Tüzük"},
+            ],
+        )


### PR DESCRIPTION
## Summary
- expose document types via `/api/documents/types`
- update document list tests and add coverage for new endpoint

## Testing
- `python -m py_compile mevzuat/documents/api.py mevzuat/documents/tests.py`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68944e38239083288331235948ae52ad