### PR TITLE
feat: show navbar search results inline

### DIFF
--- a/frontend/components/navbar.tsx
+++ b/frontend/components/navbar.tsx
@@ -21,13 +21,13 @@ import {
   CommandInput,
   CommandList,
   CommandEmpty,
+  CommandItem,
 } from "@/components/ui/command"
 import {
   useDocumentsChart,
   RangeOption,
 } from "@/components/documents-chart-context"
 import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
 import { format } from "date-fns"
 
 export default function Navbar() {
@@ -39,10 +39,13 @@ export default function Navbar() {
     setRangeOption,
     customRange,
     setCustomRange,
+    typeLabelToId,
   } = useDocumentsChart()
   const [query, setQuery] = useState("")
   const [commandOpen, setCommandOpen] = useState(false)
-  const router = useRouter()
+  const [vectorStores, setVectorStores] = useState<{ id: string; name: string }[]>([])
+  const [results, setResults] = useState<any[]>([])
+  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
@@ -55,11 +58,92 @@ export default function Navbar() {
     return () => document.removeEventListener("keydown", down)
   }, [])
 
-  function onSearch(e: React.FormEvent<HTMLFormElement>) {
+  useEffect(() => {
+    async function fetchVectorStores() {
+      try {
+        const res = await fetch("/api/documents/vector-stores")
+        const data = await res.json()
+        const mapped = (data || []).map((d: any) => ({ id: d.uuid, name: d.name }))
+        setVectorStores(mapped)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchVectorStores()
+  }, [])
+
+  function buildFilters() {
+    const filters: any[] = []
+    const typeIds = Object.entries(visible)
+      .filter(([, v]) => v)
+      .map(([label]) => typeLabelToId[label])
+      .filter(Boolean)
+    if (typeIds.length) {
+      const typeFilters = typeIds.map((id) => ({
+        type: "eq",
+        key: "mevzuat_tur",
+        value: id,
+      }))
+      filters.push(
+        typeFilters.length === 1
+          ? typeFilters[0]
+          : { type: "or", filters: typeFilters },
+      )
+    }
+
+    const today = new Date()
+    let start: string | undefined
+    let end: string | undefined
+    if (rangeOption === "thisYear") {
+      start = `${today.getFullYear()}-01-01`
+      end = today.toISOString().split("T")[0]
+    } else if (rangeOption === "lastYear") {
+      const year = today.getFullYear() - 1
+      start = `${year}-01-01`
+      end = `${year}-12-31`
+    } else if (rangeOption === "custom" && customRange?.from && customRange?.to) {
+      start = customRange.from.toISOString().split("T")[0]
+      end = customRange.to.toISOString().split("T")[0]
+    } else if (rangeOption === "30days") {
+      const past = new Date(today)
+      past.setDate(past.getDate() - 30)
+      start = past.toISOString().split("T")[0]
+      end = today.toISOString().split("T")[0]
+    }
+    if (start)
+      filters.push({ type: "gte", key: "date", value: start })
+    if (end) filters.push({ type: "lte", key: "date", value: end })
+
+    if (filters.length === 0) return undefined
+    if (filters.length === 1) return filters[0]
+    return { type: "and", filters }
+  }
+
+  async function onSearch(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    if (!query.trim()) return
-    router.push(`/search?q=${encodeURIComponent(query.trim())}`)
-    setQuery("")
+    const q = query.trim()
+    if (!q || vectorStores.length === 0) return
+    setLoading(true)
+    try {
+      const filter = buildFilters()
+      const responses = await Promise.all(
+        vectorStores.map((vs) =>
+          fetch(`/api/documents/vector-stores/${vs.id}/search`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ query: q, filters: filter }),
+          }).then((r) => r.json()),
+        ),
+      )
+      const combined = responses.flatMap((r) => r?.data || [])
+      setResults(combined)
+      setCommandOpen(true)
+    } catch (err) {
+      console.error(err)
+      setResults([])
+    } finally {
+      setLoading(false)
+    }
   }
 
   const activeSeries = Object.entries(visible)
@@ -195,9 +279,27 @@ export default function Navbar() {
         </Link>
       </nav>
       <CommandDialog open={commandOpen} onOpenChange={setCommandOpen}>
-        <CommandInput placeholder="Type a command or search..." />
+        <CommandInput placeholder="Search results" />
         <CommandList>
-          <CommandEmpty>No results found.</CommandEmpty>
+          {results.length > 0 ? (
+            results.map((r, i) => (
+              <CommandItem
+                key={i}
+                className="flex flex-col items-start gap-1"
+              >
+                <span className="font-medium">
+                  {r?.metadata?.title || `Result ${i + 1}`}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {r?.content?.[0]?.text || r?.snippet || ""}
+                </span>
+              </CommandItem>
+            ))
+          ) : (
+            <CommandEmpty>
+              {loading ? "Searching..." : "No results found."}
+            </CommandEmpty>
+          )}
         </CommandList>
       </CommandDialog>
     </>


### PR DESCRIPTION
## Summary
- search from navbar without redirect
- show filtered search results in a command dialog
- build vector store search filters without using unsupported `in` operator

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689658926b3c8328ba414e0952852c9d