### PR TITLE
fix: ensure calendar popover fits dual months

### DIFF
--- a/frontend/components/search-navbar.tsx
+++ b/frontend/components/search-navbar.tsx
@@ -211,7 +211,7 @@ export default function SearchNavbar() {
                   : "Custom"}
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="p-0" align="start">
+            <PopoverContent className="w-auto p-0" align="start">
               <Calendar
                 mode="range"
                 numberOfMonths={2}


### PR DESCRIPTION
## Summary
- ensure calendar popover expands to display both months when selecting custom ranges

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_b_6897046f298c8328b1926a58e3779a71