### PR TITLE
feat: widen date range buttons and reset custom calendar

### DIFF
--- a/frontend/components/search-navbar.tsx
+++ b/frontend/components/search-navbar.tsx
@@ -181,7 +181,12 @@ export default function SearchNavbar() {
           <ToggleGroup
             type="single"
             value={rangeOption === "custom" ? undefined : rangeOption}
-            onValueChange={(val) => val && setRangeOption(val as RangeOption)}
+            onValueChange={(val) => {
+              if (val) {
+                setRangeOption(val as RangeOption)
+                setCustomRange(undefined)
+              }
+            }}
             variant="outline"
             size="sm"
             className="flex"
@@ -192,7 +197,7 @@ export default function SearchNavbar() {
               ["lastYear", "Last Year"],
               ["30days", "30 Days"],
             ] as [RangeOption, string][]).map(([key, label]) => (
-              <ToggleGroupItem key={key} value={key}>
+              <ToggleGroupItem key={key} value={key} className="flex-none w-24">
                 {label}
               </ToggleGroupItem>
             ))}


### PR DESCRIPTION
## Summary
- widen search navbar date range buttons to show full labels
- clear custom date range when preset range is chosen

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_b_6897197e8e0883289f2183a674aa4107