### PR TITLE
Display search results below bar chart

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,9 +1,11 @@
 import DocumentsChart from "@/components/documents-chart"
+import SearchResults from "@/components/search-results"
 
 export default function Home() {
   return (
     <main className="p-6">
       <DocumentsChart />
+      <SearchResults />
     </main>
   )
 }

--- a/frontend/components/search-navbar.tsx
+++ b/frontend/components/search-navbar.tsx
@@ -5,9 +5,9 @@ import {
   useDocumentsChart,
   RangeOption,
 } from "@/components/documents-chart-context"
-import { useState, useEffect } from "react"
+import { useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { CommandDialog, CommandInput, CommandList, CommandEmpty, CommandItem } from "@/components/ui/command"
 import {
   Popover,
   PopoverTrigger,
@@ -28,115 +28,18 @@ export default function SearchNavbar() {
     setRangeOption,
     customRange,
     setCustomRange,
-    typeLabelToId,
   } = useDocumentsChart()
   const [query, setQuery] = useState("")
-  const [commandOpen, setCommandOpen] = useState(false)
-  const [vectorStores, setVectorStores] = useState<{ id: string; name: string }[]>([])
-  const [results, setResults] = useState<any[]>([])
-  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+  const searchParams = useSearchParams()
 
-  useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault()
-        setCommandOpen((o) => !o)
-      }
-    }
-    document.addEventListener("keydown", down)
-    return () => document.removeEventListener("keydown", down)
-  }, [])
-
-  useEffect(() => {
-    async function fetchVectorStores() {
-      try {
-        const res = await fetch("/api/documents/vector-stores")
-        const data = await res.json()
-        const mapped = (data || []).map((d: any) => ({ id: d.uuid, name: d.name }))
-        setVectorStores(mapped)
-      } catch (err) {
-        console.error(err)
-      }
-    }
-    fetchVectorStores()
-  }, [])
-
-  // ---------------------------------------------------------------------------
-  // Doc type visibility
-  // ---------------------------------------------------------------------------
-
-  function buildFilters() {
-    const filters: any[] = []
-    const typeIds = Object.entries(visible)
-      .filter(([, v]) => v)
-      .map(([label]) => typeLabelToId[label])
-      .filter(Boolean)
-    if (typeIds.length) {
-      const typeFilters = typeIds.map((id) => ({
-        type: "eq",
-        key: "mevzuat_tur",
-        value: id,
-      }))
-      filters.push(
-        typeFilters.length === 1
-          ? typeFilters[0]
-          : { type: "or", filters: typeFilters },
-      )
-    }
-
-    const today = new Date()
-    let start: string | undefined
-    let end: string | undefined
-    if (rangeOption === "thisYear") {
-      start = `${today.getFullYear()}-01-01`
-      end = today.toISOString().split("T")[0]
-    } else if (rangeOption === "lastYear") {
-      const year = today.getFullYear() - 1
-      start = `${year}-01-01`
-      end = `${year}-12-31`
-    } else if (rangeOption === "custom" && customRange?.from && customRange?.to) {
-      start = customRange.from.toISOString().split("T")[0]
-      end = customRange.to.toISOString().split("T")[0]
-    } else if (rangeOption === "30days") {
-      const past = new Date(today)
-      past.setDate(past.getDate() - 30)
-      start = past.toISOString().split("T")[0]
-      end = today.toISOString().split("T")[0]
-    }
-    if (start)
-      filters.push({ type: "gte", key: "date", value: start })
-    if (end) filters.push({ type: "lte", key: "date", value: end })
-
-    if (filters.length === 0) return undefined
-    if (filters.length === 1) return filters[0]
-    return { type: "and", filters }
-  }
-
-  async function onSearch(e: React.FormEvent<HTMLFormElement>) {
+  function onSearch(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const q = query.trim()
-    if (!q || vectorStores.length === 0) return
-    setLoading(true)
-    try {
-      const filter = buildFilters()
-      const responses = await Promise.all(
-        vectorStores.map((vs) =>
-          fetch(`/api/documents/vector-stores/${vs.id}/search`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ query: q, filters: filter }),
-          }).then((r) => r.json()),
-        ),
-      )
-      const combined = responses.flatMap((r) => r?.data || [])
-      setResults(combined)
-      setCommandOpen(true)
-    } catch (err) {
-      console.error(err)
-      setResults([])
-    } finally {
-      setLoading(false)
-    }
+    if (!q) return
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("q", q)
+    router.push(`/?${params.toString()}`)
   }
 
   return (
@@ -235,38 +138,11 @@ export default function SearchNavbar() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search..."
-              className="h-8 w-full pl-8 pr-12"
+              className="h-8 w-full pl-8 pr-2"
             />
-            <kbd className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
-              ⌘K
-            </kbd>
           </div>
         </form>
       </nav>
-      <CommandDialog open={commandOpen} onOpenChange={setCommandOpen}>
-        <CommandInput placeholder="Search results" />
-        <CommandList>
-          {results.length > 0 ? (
-            results.map((r, i) => (
-              <CommandItem
-                key={i}
-                className="flex flex-col items-start gap-1"
-              >
-                <span className="font-medium">
-                  {r?.metadata?.title || `Result ${i + 1}`}
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  {r?.content?.[0]?.text || r?.snippet || ""}
-                </span>
-              </CommandItem>
-            ))
-          ) : (
-            <CommandEmpty>
-              {loading ? "Searching..." : "No results found."}
-            </CommandEmpty>
-          )}
-        </CommandList>
-      </CommandDialog>
     </>
   )
 }

--- a/frontend/components/search-results.tsx
+++ b/frontend/components/search-results.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useSearchParams } from "next/navigation"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { useDocumentsChart } from "@/components/documents-chart-context"
+
+interface VectorStore {
+  id: string
+  name: string
+}
+
+export default function SearchResults() {
+  const searchParams = useSearchParams()
+  const query = searchParams.get("q")?.trim() || ""
+
+  const { rangeOption, customRange, visible, typeLabelToId } = useDocumentsChart()
+
+  const [vectorStores, setVectorStores] = useState<VectorStore[]>([])
+  const [results, setResults] = useState<any[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    async function fetchVectorStores() {
+      try {
+        const res = await fetch("/api/documents/vector-stores")
+        const data = await res.json()
+        const mapped = (data || []).map((d: any) => ({ id: d.uuid, name: d.name }))
+        setVectorStores(mapped)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchVectorStores()
+  }, [])
+
+  function buildFilters() {
+    const filters: any[] = []
+    const typeIds = Object.entries(visible)
+      .filter(([, v]) => v)
+      .map(([label]) => typeLabelToId[label])
+      .filter(Boolean)
+    if (typeIds.length) {
+      const typeFilters = typeIds.map((id) => ({
+        type: "eq",
+        key: "mevzuat_tur",
+        value: id,
+      }))
+      filters.push(
+        typeFilters.length === 1
+          ? typeFilters[0]
+          : { type: "or", filters: typeFilters },
+      )
+    }
+
+    const today = new Date()
+    let start: string | undefined
+    let end: string | undefined
+    if (rangeOption === "thisYear") {
+      start = `${today.getFullYear()}-01-01`
+      end = today.toISOString().split("T")[0]
+    } else if (rangeOption === "lastYear") {
+      const year = today.getFullYear() - 1
+      start = `${year}-01-01`
+      end = `${year}-12-31`
+    } else if (rangeOption === "custom" && customRange?.from && customRange?.to) {
+      start = customRange.from.toISOString().split("T")[0]
+      end = customRange.to.toISOString().split("T")[0]
+    } else if (rangeOption === "30days") {
+      const past = new Date(today)
+      past.setDate(past.getDate() - 30)
+      start = past.toISOString().split("T")[0]
+      end = today.toISOString().split("T")[0]
+    }
+    if (start)
+      filters.push({ type: "gte", key: "date", value: start })
+    if (end) filters.push({ type: "lte", key: "date", value: end })
+
+    if (filters.length === 0) return undefined
+    if (filters.length === 1) return filters[0]
+    return { type: "and", filters }
+  }
+
+  useEffect(() => {
+    if (!query || vectorStores.length === 0) return
+    ;(async () => {
+      setLoading(true)
+      try {
+        const filter = buildFilters()
+        const responses = await Promise.all(
+          vectorStores.map((vs) =>
+            fetch(`/api/documents/vector-stores/${vs.id}/search`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ query, filters: filter }),
+            }).then((r) => r.json()),
+          ),
+        )
+        const combined = responses.flatMap((r) => r?.data || [])
+        setResults(combined)
+      } catch (err) {
+        console.error(err)
+        setResults([])
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [query, vectorStores, rangeOption, customRange, visible])
+
+  if (!query) return null
+
+  return (
+    <div className="mt-6 space-y-4">
+      {loading ? (
+        <div>Searching...</div>
+      ) : results.length > 0 ? (
+        results.map((r, i) => {
+          const title = r?.metadata?.title || `Result ${i + 1}`
+          const date =
+            r?.metadata?.resmi_gazete_tarihi || r?.metadata?.date || ""
+          const fullSnippet =
+            r?.content?.map((c: any) => c.text).join(" ") || r?.snippet || ""
+          const shortSnippet =
+            fullSnippet.length > 200
+              ? fullSnippet.slice(0, 200) + "..."
+              : fullSnippet
+
+          const pdfUrl = buildPdfUrl(r?.metadata)
+
+          return (
+            <Dialog key={i}>
+              <DialogTrigger asChild>
+                <Card className="cursor-pointer">
+                  <CardHeader>
+                    <CardTitle>{title}</CardTitle>
+                    {date && <CardDescription>{date}</CardDescription>}
+                  </CardHeader>
+                  <CardContent>{shortSnippet}</CardContent>
+                </Card>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>{title}</DialogTitle>
+                  {date && <DialogDescription>{date}</DialogDescription>}
+                </DialogHeader>
+                <div className="whitespace-pre-wrap">{fullSnippet}</div>
+                {pdfUrl && (
+                  <Button asChild className="mt-4">
+                    <a href={pdfUrl} target="_blank" rel="noopener noreferrer">
+                      Download PDF
+                    </a>
+                  </Button>
+                )}
+              </DialogContent>
+            </Dialog>
+          )
+        })
+      ) : (
+        <div>No results found.</div>
+      )}
+    </div>
+  )
+}
+
+function buildPdfUrl(meta: any): string | null {
+  if (
+    meta?.mevzuat_tur &&
+    meta?.mevzuat_tertib &&
+    meta?.mevzuat_no
+  ) {
+    return `https://www.mevzuat.gov.tr/MevzuatMetin/${meta.mevzuat_tur}.${meta.mevzuat_tertib}.${meta.mevzuat_no}.pdf`
+  }
+  if (meta?.pdf_url) return meta.pdf_url
+  if (meta?.document_url) return meta.document_url
+  return null
+}
+


### PR DESCRIPTION
## Summary
- Show search results below the documents bar chart
- Clicking a result opens a dialog with the full snippet and PDF link
- Simplify navbar search to push query parameters instead of using a popup

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68972891501c8328884dbb4886b077d0