### PR TITLE
Unify document search and chart listings

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,11 +1,18 @@
+"use client"
+
+import { useState } from "react"
 import DocumentsChart from "@/components/documents-chart"
 import SearchResults from "@/components/search-results"
 
 export default function Home() {
+  const [listResults, setListResults] = useState<any[]>([])
   return (
     <main className="p-6">
-      <DocumentsChart />
-      <SearchResults />
+      <DocumentsChart onDocuments={setListResults} />
+      <SearchResults
+        externalResults={listResults}
+        clearExternal={() => setListResults([])}
+      />
     </main>
   )
 }

--- a/frontend/components/document-item.tsx
+++ b/frontend/components/document-item.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+
+interface DocumentItemProps {
+  title: string
+  date?: string
+  type?: string
+  snippet?: string
+  fullSnippet?: string
+  score?: number
+  pdfUrl?: string | null
+}
+
+export default function DocumentItem({
+  title,
+  date,
+  type,
+  snippet,
+  fullSnippet,
+  score,
+  pdfUrl,
+}: DocumentItemProps) {
+  const meta = [
+    date,
+    type,
+    score !== undefined ? `Score: ${score.toFixed(2)}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(" • ")
+
+  const card = (
+    <Card className="cursor-pointer">
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {meta && <CardDescription>{meta}</CardDescription>}
+      </CardHeader>
+      {snippet && <CardContent>{snippet}</CardContent>}
+    </Card>
+  )
+
+  if (!fullSnippet && !pdfUrl) return card
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{card}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {meta && <DialogDescription>{meta}</DialogDescription>}
+        </DialogHeader>
+        {fullSnippet && (
+          <div className="whitespace-pre-wrap">{fullSnippet}</div>
+        )}
+        {pdfUrl && (
+          <Button asChild className="mt-4">
+            <a href={pdfUrl} target="_blank" rel="noopener noreferrer">
+              Download PDF
+            </a>
+          </Button>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+


### PR DESCRIPTION
## Summary
- Add reusable `DocumentItem` component for document title, date, type, snippet, score and PDF link
- Replace separate search and chart lists with a single unified results list driven by `SearchResults`
- Emit document selections from `DocumentsChart` to the main page for unified display

## Testing
- `npm run lint` (fails: prompts for ESLint configuration)
- `npm test` (fails: Missing script)
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_6897367870a08328bb84e055e08264b6