### PR TITLE
feat: sync documents with vector store

### DIFF
--- a/mevzuat/documents/admin.py
+++ b/mevzuat/documents/admin.py
@@ -46,7 +46,7 @@ class DocumentAdmin(admin.ModelAdmin):
     actions = (
         "fetch_original",
         "convert_to_markdown",
-        "upload_to_vectorstore",
+        "sync_with_vectorstore",
     )
 
     def mevzuat_no(self, obj):
@@ -110,19 +110,23 @@ class DocumentAdmin(admin.ModelAdmin):
                 level=messages.WARNING,
             )
 
-    def upload_to_vectorstore(self, request, queryset):
+    def sync_with_vectorstore(self, request, queryset):
         ok, failed = 0, 0
         for obj in queryset:
-            obj.upload_to_vectorstore()
+            try:
+                obj.sync_with_vectorstore()
+                ok += 1
+            except Exception:
+                failed += 1
         if ok:
             self.message_user(
                 request,
-                f"Successfully uploaded {ok} document(s).",
+                f"Successfully synced {ok} document(s).",
                 level=messages.SUCCESS,
             )
         if failed:
             self.message_user(
                 request,
-                f"{failed} document(s) could not be uploaded – see log.",
+                f"{failed} document(s) could not be synced – see log.",
                 level=messages.WARNING,
             )

--- a/mevzuat/documents/models.py
+++ b/mevzuat/documents/models.py
@@ -116,5 +116,6 @@ class Document(models.Model):
     def convert_pdf_to_markdown(self, overwrite=False):
         return self._fetcher().convert_pdf_to_markdown(self, overwrite=overwrite)
 
-    def upload_to_vectorstore(self):
-        return self._fetcher().upload_to_vectorstore(self)
+    def sync_with_vectorstore(self):
+        """Synchronise this document with the configured vector store."""
+        return self._fetcher().sync_with_vectorstore(self)


### PR DESCRIPTION
## Summary
- rename vector store upload to sync_with_vectorstore
- update existing file metadata when already uploaded
- add admin action to sync documents with vector store

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68978456fb9083289569a1ea3d176720