### PR TITLE
Add MCP server for Mevzuat documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ npx shadcn@latest init
 npm install recharts
 
 
+## MCP server
+
+The repository includes a simple [Model Context Protocol](https://github.com/modelcontextprotocol/standard) server that exposes stored Mevzuat documents to MCP-compliant agents. After installing backend dependencies and setting up the database, run:
+
+```bash
+python scripts/mevzuat_mcp_server.py
+```
+
+The server lists each document as a resource and returns the markdown content when available, falling back to JSON metadata otherwise.
+
 ## Contributing
 
 Contributions are welcome. Please ensure code changes are checked with `python -m py_compile` before submitting.


### PR DESCRIPTION
## Summary
- add Model Context Protocol server for serving Mevzuat documents to agents
- document new MCP server and how to run it

## Testing
- `python -m py_compile scripts/mevzuat_mcp_server.py`


------
https://chatgpt.com/codex/tasks/task_b_6898252cd0ac83288b1f03dcb354882d