### PR TITLE
Fix search results rendering and align MCP endpoint

### DIFF
--- a/mevzuat/mcp_server/handlers.py
+++ b/mevzuat/mcp_server/handlers.py
@@ -174,11 +174,17 @@ def search_documents(
             search_kwargs["filters"] = filter_obj
         response = client.vector_stores.search(**search_kwargs)
 
-        # ``vector_stores.search`` returns a ``SyncPage`` with the results on the
-        # ``data`` attribute.  Convert each ``VectorStoreSearchResponse`` to a
-        # plain dict so the output matches the REST API.
-        items = [item.model_dump() for item in response.data]
-        results.extend(items)
+        for item in response.data:
+            for c in item.content:
+                results.append(
+                    {
+                        "text": c.text,
+                        "type": c.type,
+                        "filename": item.filename,
+                        "score": item.score,
+                        "attributes": item.attributes,
+                    }
+                )
 
     results.sort(key=lambda r: r.get("score", 0), reverse=True)
     return {"data": results[:limit]}

--- a/mevzuat/templates/home.html
+++ b/mevzuat/templates/home.html
@@ -204,11 +204,19 @@
       if (end) params.set('end_date', end);
       const res = await fetch('/api/documents/search?' + params.toString());
       if (!res.ok) return;
-      const docs = await res.json();
-      if (!Array.isArray(docs) || !docs.length) {
+      const { data } = await res.json();
+      if (!Array.isArray(data) || !data.length) {
         resultsDiv.innerHTML = '<div class="alert alert-warning">No results</div>';
       } else {
-        resultsDiv.innerHTML = '<ul class="list-group mb-4">' + docs.map(d => `<li class="list-group-item">${d.title}</li>`).join('') + '</ul>';
+        resultsDiv.innerHTML =
+          '<ul class="list-group mb-4">' +
+          data
+            .map(d => {
+              const title = d.attributes && d.attributes.title ? d.attributes.title : d.filename;
+              return `<li class="list-group-item"><strong>${title}</strong><br>${d.text}</li>`;
+            })
+            .join('') +
+          '</ul>';
       }
     });
   });


### PR DESCRIPTION
## Summary
- Render search results correctly on homepage
- Return document search results as dictionaries in MCP handler

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a061eded8483288c1d4faa56ea0c41