### PR TITLE
Enable infinite scroll for search results

### DIFF
--- a/mevzuat/mcp_server/handlers.py
+++ b/mevzuat/mcp_server/handlers.py
@@ -117,6 +117,7 @@ def search_documents(
     end_date: date | None = None,
     score_threshold: float | None = None,
     limit: int = 10,
+    offset: int = 0,
 ) -> dict[str, Any]:
     """Search documents across all vector stores."""
     if type:
@@ -162,11 +163,12 @@ def search_documents(
         ranking_options["score_threshold"] = score_threshold
 
     results: list[dict[str, Any]] = []
+    fetch_count = offset + limit + 1
     for vs_id in vector_store_ids:
         search_kwargs = {
             "vector_store_id": vs_id,
             "query": query,
-            "max_num_results": limit,
+            "max_num_results": fetch_count,
             "ranking_options": ranking_options or None,
             "rewrite_query": True,
         }
@@ -187,7 +189,9 @@ def search_documents(
                 )
 
     results.sort(key=lambda r: r.get("score", 0), reverse=True)
-    return {"data": results[:limit]}
+    page = results[offset:offset + limit]
+    has_more = len(results) > offset + limit
+    return {"data": page, "has_more": has_more}
 
 
 __all__ = [

--- a/mevzuat/templates/search_results.html
+++ b/mevzuat/templates/search_results.html
@@ -87,16 +87,28 @@ document.addEventListener('DOMContentLoaded', () => {
     return { start, end };
   }
 
-  async function performSearch() {
-    resultsDiv.innerHTML = '<div class="text-center my-4"><div class="spinner-border" role="status"></div></div>';
+  const PAGE_SIZE = 10;
+  let currentOffset = 0;
+  let hasMore = false;
+  let loading = false;
+  const observer = new IntersectionObserver(entries => {
+    if (entries[0].isIntersecting && hasMore && !loading) {
+      fetchResults(true);
+    }
+  });
+
+  async function fetchResults(append = false) {
+    if (loading) return;
+    loading = true;
+
     const q = searchInput.value.trim();
-    if (!q) { resultsDiv.innerHTML = ''; return; }
+    if (!q) { resultsDiv.innerHTML = ''; loading = false; return; }
 
     const selectedSlugs = Object.keys(typeMap)
       .filter(label => typeMap[label].visible)
       .map(label => typeMap[label].slug);
 
-    const params = new URLSearchParams({ query: q });
+    const params = new URLSearchParams({ query: q, limit: PAGE_SIZE, offset: currentOffset });
     const { start, end } = getRange();
     if (start) params.set('start_date', start);
     if (end) params.set('end_date', end);
@@ -104,39 +116,70 @@ document.addEventListener('DOMContentLoaded', () => {
       params.set('type', selectedSlugs[0]);
     }
 
+    if (!append) {
+      resultsDiv.innerHTML = '<div class="text-center my-4"><div class="spinner-border" role="status"></div></div>';
+    } else {
+      const sentinel = document.getElementById('scrollSentinel');
+      if (sentinel) sentinel.innerHTML = '<div class="spinner-border" role="status"></div>';
+    }
+
     try {
       const res = await fetch('/api/documents/search?' + params.toString());
-      if (!res.ok) {
-        resultsDiv.innerHTML = '<div class="alert alert-danger">Search failed</div>';
-        return;
-      }
-      let { data } = await res.json();
+      if (!res.ok) throw new Error('Search failed');
+      let { data, has_more } = await res.json();
       if (selectedSlugs.length > 1) {
         data = data.filter(d => selectedSlugs.includes(d.attributes?.type));
       }
-      if (!Array.isArray(data) || !data.length) {
-        resultsDiv.innerHTML = '<div class="alert alert-warning">No results</div>';
-      } else {
-        resultsDiv.innerHTML =
-          '<ul class="list-group mb-4">' +
-          data.map(d => {
-            const title = d.attributes && d.attributes.title ? d.attributes.title : d.filename;
-            const date = d.attributes?.date || '';
-            const typeSlug = d.attributes?.type || '';
-            const typeLabel = slugToLabel[typeSlug] || typeSlug;
-            const score = typeof d.score === 'number' ? d.score.toFixed(2) : '';
-            const metaParts = [];
-            if (date) metaParts.push(date);
-            if (typeLabel) metaParts.push(typeLabel);
-            if (score) metaParts.push(`Relevance: ${score}`);
-            const meta = metaParts.join(' | ');
-            return `<li class="list-group-item"><strong>${title}</strong><br><small class="text-muted">${meta}</small><br>${d.text}</li>`;
-          }).join('') +
-          '</ul>';
+      if (!append) {
+        if (!Array.isArray(data) || !data.length) {
+          resultsDiv.innerHTML = '<div class="alert alert-warning">No results</div>';
+          hasMore = false;
+          loading = false;
+          return;
+        }
+        resultsDiv.innerHTML = '<ul id="resultsList" class="list-group mb-4"></ul><div id="scrollSentinel"></div>';
+      }
+      const list = document.getElementById('resultsList');
+      list.insertAdjacentHTML('beforeend', data.map(d => {
+        const title = d.attributes && d.attributes.title ? d.attributes.title : d.filename;
+        const date = d.attributes?.date || '';
+        const typeSlug = d.attributes?.type || '';
+        const typeLabel = slugToLabel[typeSlug] || typeSlug;
+        const score = typeof d.score === 'number' ? d.score.toFixed(2) : '';
+        const metaParts = [];
+        if (date) metaParts.push(date);
+        if (typeLabel) metaParts.push(typeLabel);
+        if (score) metaParts.push(`Relevance: ${score}`);
+        const meta = metaParts.join(' | ');
+        return `<li class="list-group-item"><strong>${title}</strong><br><small class="text-muted">${meta}</small><br>${d.text}</li>`;
+      }).join(''));
+      currentOffset += data.length;
+      hasMore = has_more;
+      if (!hasMore) {
+        observer.disconnect();
+        const sentinel = document.getElementById('scrollSentinel');
+        if (sentinel) sentinel.remove();
       }
     } catch (err) {
       console.error(err);
-      resultsDiv.innerHTML = '<div class="alert alert-danger">Search failed</div>';
+      if (!append) {
+        resultsDiv.innerHTML = '<div class="alert alert-danger">Search failed</div>';
+      }
+    } finally {
+      loading = false;
+      const sentinel = document.getElementById('scrollSentinel');
+      if (sentinel) sentinel.innerHTML = '';
+    }
+  }
+
+  async function performSearch() {
+    observer.disconnect();
+    currentOffset = 0;
+    hasMore = false;
+    await fetchResults(false);
+    if (hasMore) {
+      const sentinel = document.getElementById('scrollSentinel');
+      if (sentinel) observer.observe(sentinel);
     }
   }
 


### PR DESCRIPTION
## Summary
- paginate `/api/documents/search` using `offset` and return `has_more`
- implement infinite scroll UI on search results page
- cover pagination with new tests and adjust existing ones

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68a596faba348328a4909e6900813b58