### PR TITLE
Expose mevzuat tertib in document admin

### DIFF
--- a/mevzuat/documents/admin.py
+++ b/mevzuat/documents/admin.py
@@ -61,11 +61,31 @@ class InVectorStoreFilter(admin.SimpleListFilter):
         return queryset
 
 
+class MevzuatTertibFilter(admin.SimpleListFilter):
+    title = "Mevzuat tertib"
+    parameter_name = "mevzuat_tertib"
+
+    def lookups(self, request, model_admin):
+        values = (
+            Document.objects.values_list("metadata__mevzuat_tertib", flat=True)
+            .distinct()
+            .order_by("metadata__mevzuat_tertib")
+        )
+        return [(v, str(v)) for v in values if v not in (None, "")]
+
+    def queryset(self, request, queryset):
+        val = self.value()
+        if val:
+            return queryset.filter(metadata__mevzuat_tertib=val)
+        return queryset
+
+
 @admin.register(Document)
 class DocumentAdmin(admin.ModelAdmin):
     list_display = (
         "title",
         "mevzuat_no",
+        "mevzuat_tertib",
         "type",
         "date",
         "has_pdf",
@@ -75,6 +95,7 @@ class DocumentAdmin(admin.ModelAdmin):
     list_filter = (
         "type",
         "date",
+        MevzuatTertibFilter,
         HasPdfFilter,
         InVectorStoreFilter,
         HasMdFilter,
@@ -88,6 +109,9 @@ class DocumentAdmin(admin.ModelAdmin):
 
     def mevzuat_no(self, obj):
         return obj.metadata.get("mevzuat_no")
+
+    def mevzuat_tertib(self, obj):
+        return obj.metadata.get("mevzuat_tertib")
 
     def resmi_gazete_tarihi(self, obj):
         return obj.metadata.get("resmi_gazete_tarihi")

--- a/mevzuat/documents/tests.py
+++ b/mevzuat/documents/tests.py
@@ -8,7 +8,7 @@ from django.contrib import admin, messages
 from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings, RequestFactory
 
-from .admin import DocumentAdmin
+from .admin import DocumentAdmin, MevzuatTertibFilter
 from .models import Document, DocumentType, VectorStore
 
 
@@ -240,6 +240,12 @@ class DocumentSearchAPITest(TestCase):
         calls = instance.vector_stores.search.call_args_list
         self.assertEqual(calls[0].kwargs["max_num_results"], 3)
         self.assertEqual(calls[1].kwargs["max_num_results"], 5)
+
+
+class DocumentAdminConfigTest(TestCase):
+    def test_mevzuat_tertib_in_admin_lists(self):
+        self.assertIn("mevzuat_tertib", DocumentAdmin.list_display)
+        self.assertIn(MevzuatTertibFilter, DocumentAdmin.list_filter)
 
 
 class DocumentAdminActionErrorTest(TestCase):


### PR DESCRIPTION
## Summary
- show `mevzuat_tertib` in Document admin list display
- allow filtering admin by `mevzuat_tertib`
- add regression test for admin configuration

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68b3092ed154832880f5ddccf73c2a2e