### PR TITLE
Add fetch_new command for documents and cookie-based scraper helper

### DIFF
--- a/mevzuat/documents/management/commands/fetch_new.py
+++ b/mevzuat/documents/management/commands/fetch_new.py
@@ -1,0 +1,56 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from ...models import DocumentType, Document
+from scripts.mevzuat_scraper import fetch_documents
+
+
+class Command(BaseCommand):
+    """Fetch the latest documents for a given ``DocumentType``."""
+
+    help = "Fetch latest documents and create Document instances if missing"
+
+    def add_arguments(self, parser):
+        parser.add_argument("slug", help="Slug of the DocumentType")
+
+    def handle(self, *args, **options):
+        slug = options["slug"]
+        try:
+            doc_type = DocumentType.objects.get(slug=slug)
+        except DocumentType.DoesNotExist:
+            raise CommandError(f"DocumentType with slug '{slug}' not found")
+
+        fetcher = doc_type._fetcher()
+        params = getattr(fetcher, "request_params", None)
+        if params is None:
+            raise CommandError(f"Fetcher '{doc_type.fetcher}' does not define request_params")
+
+        rows = fetch_documents(params)
+
+        created = 0
+        for row in rows:
+            title = (
+                row.get("title")
+                or row.get("baslik")
+                or row.get("mevzuat_basligi")
+                or ""
+            )
+
+            lookup = {
+                "type": doc_type,
+                "metadata__mevzuat_tur": row.get("mevzuat_tur"),
+                "metadata__mevzuat_tertib": row.get("mevzuat_tertib"),
+                "metadata__mevzuat_no": row.get("mevzuat_no"),
+            }
+            defaults = {"title": title, "metadata": row}
+
+            _, was_created = Document.objects.get_or_create(
+                defaults=defaults, **lookup
+            )
+            if was_created:
+                created += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Processed {len(rows)} items – {created} new documents created."
+            )
+        )

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts package."""


### PR DESCRIPTION
## Summary
- add `fetch_new` management command to retrieve latest documents for a given type
- expose `fetch_documents` in `mevzuat_scraper` that handles antiforgery cookie and request parameters
- make scripts importable as a package

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68b40761ff748328bc7bd935209bfaaf