### PR TITLE
Add command to fetch missing document files

### DIFF
--- a/mevzuat/documents/management/commands/fetch_documents.py
+++ b/mevzuat/documents/management/commands/fetch_documents.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from ...models import Document
+
+
+class Command(BaseCommand):
+    """Fetch and store missing document files for active document types."""
+
+    help = "Fetch missing document files for active document types"
+
+    def handle(self, *args, **options):
+        queryset = Document.objects.filter(type__active=True).filter(
+            Q(document__isnull=True) | Q(document="")
+        )
+
+        total = queryset.count()
+        if total == 0:
+            self.stdout.write(self.style.SUCCESS("No documents to fetch."))
+            return
+
+        for doc in queryset.iterator():
+            doc.fetch_and_store_document()
+            self.stdout.write(f"Fetched document {doc.pk}")
+
+        self.stdout.write(self.style.SUCCESS(f"Fetched {total} documents."))


### PR DESCRIPTION
## Summary
- add `fetch_documents` management command to download document files missing from active types
- cover command and admin error handling in tests
- fix test metadata keys for document dates

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68b4798923888328a8d4bd4b8e3f6fc5